### PR TITLE
refactor: remove dead code from GitHub client module (Phase 2)

### DIFF
--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -3,11 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  GitHubClient,
-  GitHubApiError,
-  isRateLimitError,
-} from "./github";
+import { GitHubClient, GitHubApiError, isRateLimitError } from "./github";
 
 // Use vi.hoisted to properly mock Octokit
 const { mockRest, MockOctokitClass, mockPaginateIterator } = vi.hoisted(() => {

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -6,7 +6,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   GitHubClient,
   GitHubApiError,
-  createGitHubClient,
   isRateLimitError,
 } from "./github";
 
@@ -15,12 +14,8 @@ const { mockRest, MockOctokitClass, mockPaginateIterator } = vi.hoisted(() => {
   const mockRest = {
     issues: {
       listForRepo: vi.fn(),
-      get: vi.fn(),
     },
     repos: {
-      get: vi.fn(),
-    },
-    rateLimit: {
       get: vi.fn(),
     },
   };
@@ -73,30 +68,6 @@ describe("GitHubClient", () => {
     it("should use custom user agent", () => {
       const client = new GitHubClient(undefined, "custom-agent");
       expect(client).toBeDefined();
-    });
-  });
-
-  describe("createGitHubClient factory", () => {
-    it("should create a client without token", () => {
-      const client = createGitHubClient();
-      expect(client).toBeInstanceOf(GitHubClient);
-    });
-
-    it("should create a client with token", () => {
-      const client = createGitHubClient("test-token");
-      expect(client).toBeInstanceOf(GitHubClient);
-    });
-  });
-
-  describe("isAuthenticated", () => {
-    it("should return false when no token provided", () => {
-      const client = new GitHubClient();
-      expect(client.isAuthenticated()).toBe(false);
-    });
-
-    it("should return true when token provided", () => {
-      const client = new GitHubClient("test-token");
-      expect(client.isAuthenticated()).toBe(true);
     });
   });
 
@@ -272,44 +243,6 @@ describe("GitHubClient", () => {
     });
   });
 
-  describe("getIssue", () => {
-    it("should fetch a single issue", async () => {
-      const mockIssue = {
-        number: 1,
-        title: "Test Issue",
-        body: "Issue body",
-        state: "open",
-        html_url: "https://github.com/owner/repo/issues/1",
-        created_at: "2024-01-01T00:00:00Z",
-        updated_at: "2024-01-02T00:00:00Z",
-        labels: [{ name: "bug" }],
-        user: { login: "testuser", type: "User" },
-      };
-
-      mockRest.issues.get.mockResolvedValue({
-        data: mockIssue,
-      });
-
-      const issue = await client.getIssue("owner", "repo", 1);
-
-      expect(issue.number).toBe(1);
-      expect(issue.title).toBe("Test Issue");
-      expect(mockRest.issues.get).toHaveBeenCalledWith({
-        owner: "owner",
-        repo: "repo",
-        issue_number: 1,
-      });
-    });
-
-    it("should handle API errors for single issue", async () => {
-      mockRest.issues.get.mockRejectedValue(new Error("Not Found"));
-
-      await expect(client.getIssue("owner", "repo", 999)).rejects.toThrow(
-        GitHubApiError,
-      );
-    });
-  });
-
   describe("getRepository", () => {
     it("should fetch repository information", async () => {
       const mockRepo = {
@@ -343,37 +276,6 @@ describe("GitHubClient", () => {
       await expect(
         client.getRepository("owner", "nonexistent"),
       ).rejects.toThrow(GitHubApiError);
-    });
-  });
-
-  describe("getRateLimit", () => {
-    it("should fetch rate limit status", async () => {
-      const mockRateLimit = {
-        resources: {
-          core: {
-            limit: 5000,
-            remaining: 4999,
-            reset: 1704067200,
-            used: 1,
-          },
-        },
-      };
-
-      mockRest.rateLimit.get.mockResolvedValue({
-        data: mockRateLimit,
-      });
-
-      const rateLimit = await client.getRateLimit();
-
-      expect(rateLimit.limit).toBe(5000);
-      expect(rateLimit.remaining).toBe(4999);
-      expect(rateLimit.used).toBe(1);
-    });
-
-    it("should handle API errors", async () => {
-      mockRest.rateLimit.get.mockRejectedValue(new Error("Rate limit error"));
-
-      await expect(client.getRateLimit()).rejects.toThrow(GitHubApiError);
     });
   });
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -11,12 +11,6 @@ import { Octokit } from "@octokit/rest";
 // Type Definitions
 // =============================================================================
 
-/** GitHub repository owner and name */
-export interface GitHubRepo {
-  owner: string;
-  name: string;
-}
-
 /** GitHub issue data */
 export interface GitHubIssue {
   number: number;
@@ -45,14 +39,6 @@ export interface GitHubRepository {
   language: string | null;
   pushed_at: string;
   default_branch: string;
-}
-
-/** GitHub rate limit status */
-export interface GitHubRateLimit {
-  limit: number;
-  remaining: number;
-  reset: number;
-  used: number;
 }
 
 function normalizeLabels(
@@ -131,8 +117,6 @@ export function isRateLimitError(error: unknown): boolean {
  */
 export class GitHubClient {
   private octokit: Octokit;
-  private userAgent: string;
-  private token?: string;
 
   /**
    * Create a new GitHub client
@@ -140,31 +124,10 @@ export class GitHubClient {
    * @param userAgent - User agent string for API requests
    */
   constructor(token?: string, userAgent = "awana-labs") {
-    this.userAgent = userAgent;
-    this.token = token;
     this.octokit = new Octokit({
       auth: token,
       userAgent,
     });
-  }
-
-  /**
-   * Set authentication token
-   * @param token - GitHub personal access token
-   */
-  setAuth(token: string): void {
-    this.token = token;
-    this.octokit = new Octokit({
-      auth: token,
-      userAgent: this.userAgent,
-    });
-  }
-
-  /**
-   * Check if client is authenticated
-   */
-  isAuthenticated(): boolean {
-    return !!this.token;
   }
 
   /**
@@ -241,44 +204,6 @@ export class GitHubClient {
   }
 
   /**
-   * Fetch a single issue by number
-   * @param owner - Repository owner
-   * @param repo - Repository name
-   * @param issueNumber - Issue number
-   */
-  async getIssue(
-    owner: string,
-    repo: string,
-    issueNumber: number,
-  ): Promise<GitHubIssue> {
-    try {
-      const response = await this.octokit.rest.issues.get({
-        owner,
-        repo,
-        issue_number: issueNumber,
-      });
-
-      const issue = response.data;
-      return {
-        number: issue.number,
-        title: issue.title,
-        body: issue.body ?? null,
-        state: issue.state || "open",
-        html_url: issue.html_url,
-        created_at: issue.created_at,
-        updated_at: issue.updated_at,
-        labels: normalizeLabels(issue.labels),
-        user: {
-          login: issue.user?.login || "",
-          type: issue.user?.type || "User",
-        },
-      };
-    } catch (error) {
-      throw this.handleError(error);
-    }
-  }
-
-  /**
    * Fetch repository information
    * @param owner - Repository owner
    * @param repo - Repository name
@@ -303,19 +228,6 @@ export class GitHubClient {
         pushed_at: data.pushed_at,
         default_branch: data.default_branch,
       };
-    } catch (error) {
-      throw this.handleError(error);
-    }
-  }
-
-  /**
-   * Check current rate limit status
-   */
-  async getRateLimit(): Promise<GitHubRateLimit> {
-    try {
-      const response = await this.octokit.rest.rateLimit.get();
-      const { limit, remaining, reset, used } = response.data.resources.core;
-      return { limit, remaining, reset, used };
     } catch (error) {
       throw this.handleError(error);
     }
@@ -371,17 +283,6 @@ export class GitHubClient {
 
     return new GitHubApiError("Unknown GitHub API error", 500);
   }
-}
-
-// =============================================================================
-// Factory Functions
-// =============================================================================
-
-/**
- * Create a GitHub client with optional token
- */
-export function createGitHubClient(token?: string): GitHubClient {
-  return new GitHubClient(token);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Remove ~195 lines of dead code from the GitHub client module — methods, interfaces, and a factory function that were defined but never called from production code.

## Context
Phase 2 of the codebase improvement plan (`plans/2026-04-18-2026-04-18-awana-labs-improvements-v5.md`) targets dead code removal. The GitHub client module had 5 methods, 2 interfaces, and 1 factory function that were only referenced by their own tests — never by production code. Only `constructor`, `getIssues()`, `getRepository()`, `handleError()`, and `isRateLimitError()` are used in production.

## Changes
- Removed `GitHubRepo` and `GitHubRateLimit` interfaces (only used by dead methods)
- Removed `setAuth()`, `isAuthenticated()`, `getIssue()`, `getRateLimit()` methods
- Removed `createGitHubClient()` factory function
- Removed unused private fields `userAgent` and `token` (only read by removed methods)
- Removed corresponding test blocks and mock entries from `github.test.ts`

## Testing
- All 168 unit tests pass (`npm run test`)
- TypeScript compilation clean (`npm run typecheck`)
- ESLint clean (`npm run lint`)
- Production build succeeds (`npm run build`)
- Code review completed with no issues found
